### PR TITLE
Add dependency on recurrent package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ This package is a virtual namespace for openaps.contrib modules.
 
 '''
 
-requires = [ ]
+requires = ['recurrent']
 
 setup(
     name='openaps-contrib',


### PR DESCRIPTION
https://github.com/openaps/openaps-contrib/commit/6181fc introduced a dependency on recurrent. Got this error after installing openaps on a fresh Pi via `quick-src.sh`:

```
pi@markpi:~/markps $ openaps use pump -h
Traceback (most recent call last):
  File "/usr/local/bin/openaps-use", line 4, in <module>
    __import__('pkg_resources').run_script('openaps==0.1.0', 'openaps-use')
  File "build/bdist.linux-armv7l/egg/pkg_resources/__init__.py", line 719, in run_script
  File "build/bdist.linux-armv7l/egg/pkg_resources/__init__.py", line 1504, in run_script
  File "/usr/local/lib/python2.7/dist-packages/openaps-0.1.0-py2.7.egg/EGG-INFO/scripts/openaps-use", line 63, in <module>
    app( )
  File "/usr/local/lib/python2.7/dist-packages/openaps-0.1.0-py2.7.egg/openaps/cli/__init__.py", line 47, in __call__
    self.configure_parser(self.parser)
  File "/usr/local/lib/python2.7/dist-packages/openaps-0.1.0-py2.7.egg/EGG-INFO/scripts/openaps-use", line 31, in configure_parser
    available = devices.get_device_map(self.config)
  File "/usr/local/lib/python2.7/dist-packages/openaps-0.1.0-py2.7.egg/openaps/devices/__init__.py", line 21, in get_device_map
    for device in Device.FromConfig(vendors, conf):
  File "/usr/local/lib/python2.7/dist-packages/openaps-0.1.0-py2.7.egg/openaps/devices/device.py", line 77, in FromConfig
    vendor = vendors.lookup(config.get(candidate, 'vendor').split('.').pop( ), config)
  File "/usr/local/lib/python2.7/dist-packages/openaps-0.1.0-py2.7.egg/openaps/vendors/__init__.py", line 27, in lookup
    return get_map(config)[name]
  File "/usr/local/lib/python2.7/dist-packages/openaps-0.1.0-py2.7.egg/openaps/vendors/__init__.py", line 22, in get_map
    vendors = all_vendors(config)
  File "/usr/local/lib/python2.7/dist-packages/openaps-0.1.0-py2.7.egg/openaps/vendors/__init__.py", line 36, in all_vendors
    return get_vendors( ) + find_plugins(config)
  File "/usr/local/lib/python2.7/dist-packages/openaps-0.1.0-py2.7.egg/openaps/vendors/__init__.py", line 16, in find_plugins
    return [ v.get_module( ) for v in vendors ]
  File "/usr/local/lib/python2.7/dist-packages/openaps-0.1.0-py2.7.egg/openaps/vendors/plugins/vendor.py", line 19, in get_module
    return importlib.import_module(self.name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/usr/local/lib/python2.7/dist-packages/openaps_contrib-0.0.8-py2.7.egg/openapscontrib/timezones/__init__.py", line 129, in <module>
    import recurrent
ImportError: No module named recurrent
```
