### PR TITLE
pyicu: 'module' object has no attribute 'Locale'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ This package is a virtual namespace for openaps.contrib modules.
 
 '''
 
-requires = ['recurrent']
+requires = ['parsedatetime==2.5', 'recurrent']
 
 setup(
     name='openaps-contrib',


### PR DESCRIPTION
recurrent requires parsedatetime; parsedatetime 2.6 causes  openaps issues (related to pyicu, see below), but 2.5 is known to be ok.

``` python
File "/usr/local/lib/python2.7/dist-packages/parsedatetime/pdt_locales/icu.py", line 56, in get_icu
result['icu'] = icu = pyicu.Locale(locale)
AttributeError: 'module' object has no attribute 'Locale'
```

@vanzaam found that the was a recent update to parsedatetime, and inspired this fix.
I've raised bear/parsedatetime#248  to see if they can fix/revert that, keeping an eye on it.